### PR TITLE
Use single Vercel Gateway requests for content updates

### DIFF
--- a/config/ai-config.json
+++ b/config/ai-config.json
@@ -1,10 +1,6 @@
 {
   "provider": "vercel-ai-gateway",
   "model": "xai/grok-4-fast-non-reasoning",
-  "bulk": {
-    "enabled": true,
-    "maxBatchSize": 50
-  },
   "topics": [
     {
       "id": "longevity",

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ Next.js application that publishes daily AI-generated briefings on the state of 
 
 ## Features
 - **AI content automation** powered by Vercel AI Gateway with configurable model and prompts per topic.
-- **Bulk generation** batching to minimize gateway spend.
+- **Direct Vercel AI Gateway integration** issuing per-topic completions with configurable models.
 - **Flexible scheduling** (daily/weekly/monthly) via Node Cron, defined through editable JSON config.
 - **Historical archives** persisted to local JSON files for easy versioning.
 - **Modern UI** with tabbed navigation, glassmorphism styling, and extensive Google Ad placements.

--- a/scripts/scheduler.ts
+++ b/scripts/scheduler.ts
@@ -12,7 +12,6 @@ interface ScheduleFile {
 interface AIConfig {
   provider: string;
   model: string;
-  bulk: { enabled: boolean; maxBatchSize: number };
   topics: TopicConfig[];
 }
 


### PR DESCRIPTION
## Summary
- replace the bulk content generation flow with per-topic requests to the configured Vercel AI Gateway endpoint
- extract AI responses from common completion payload shapes and continue to fall back to mock content when needed
- update scheduling, configuration, and documentation to reflect the removal of bulk batch settings

## Testing
- npm run lint *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e23de151b8832595228315a6993f0e