### PR TITLE
Enable structured longevity visuals

### DIFF
--- a/components/FundingVisualizer.tsx
+++ b/components/FundingVisualizer.tsx
@@ -1,0 +1,121 @@
+import type { FundingPoint } from '@/lib/types';
+
+interface FundingVisualizerProps {
+  series: FundingPoint[];
+  notes?: string[];
+}
+
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 1,
+  notation: 'compact'
+});
+
+function formatChange(value?: number) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return '—';
+  }
+  const percentage = (value * 100).toFixed(Math.abs(value * 100) >= 10 ? 0 : 1);
+  const prefix = value > 0 ? '+' : value < 0 ? '−' : '';
+  return `${prefix}${Math.abs(Number(percentage)).toString()}%`;
+}
+
+export function FundingVisualizer({ series, notes }: FundingVisualizerProps) {
+  if (!series.length) return null;
+
+  const width = 600;
+  const height = 220;
+  const padding = 32;
+  const effectiveWidth = width - padding * 2;
+  const effectiveHeight = height - padding * 2;
+  const totals = series.map((point) => point.totalCapitalUsd);
+  const max = Math.max(...totals);
+  const min = Math.min(...totals);
+  const range = max - min || 1;
+
+  const points = series.map((point, index) => {
+    const ratio = series.length > 1 ? index / (series.length - 1) : 0.5;
+    const valueRatio = (point.totalCapitalUsd - min) / range;
+    const x = padding + ratio * effectiveWidth;
+    const y = height - padding - valueRatio * effectiveHeight;
+    return { x, y };
+  });
+
+  const linePath = points
+    .map((point, index) => `${index === 0 ? 'M' : 'L'} ${point.x.toFixed(2)} ${point.y.toFixed(2)}`)
+    .join(' ');
+
+  const areaPath = [
+    `M ${points[0]?.x.toFixed(2) ?? padding} ${height - padding}`,
+    `${points[0] ? `L ${points[0].x.toFixed(2)} ${points[0].y.toFixed(2)}` : ''}`,
+    ...points.slice(1).map((point) => `L ${point.x.toFixed(2)} ${point.y.toFixed(2)}`),
+    `L ${points[points.length - 1]?.x.toFixed(2) ?? width - padding} ${height - padding}`,
+    'Z'
+  ].join(' ');
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-2xl border border-slate-700/60 bg-slate-900/40 p-6">
+        <svg viewBox={`0 0 ${width} ${height}`} className="h-52 w-full">
+          <defs>
+            <linearGradient id="funding-gradient" x1="0" x2="0" y1="0" y2="1">
+              <stop offset="0%" stopColor="rgba(56, 189, 248, 0.45)" />
+              <stop offset="100%" stopColor="rgba(56, 189, 248, 0)" />
+            </linearGradient>
+          </defs>
+          <path d={areaPath} fill="url(#funding-gradient)" />
+          <path d={linePath} fill="none" stroke="rgba(56, 189, 248, 0.9)" strokeWidth={3} strokeLinejoin="round" />
+          {points.map((point, index) => (
+            <g key={`${point.x}-${index}`}>
+              <circle cx={point.x} cy={point.y} r={5} fill="#38bdf8" stroke="#0f172a" strokeWidth={2} />
+              <text
+                x={point.x}
+                y={point.y - 10}
+                textAnchor="middle"
+                className="fill-slate-200 text-[10px]"
+              >
+                {currencyFormatter.format(series[index].totalCapitalUsd)}
+              </text>
+            </g>
+          ))}
+        </svg>
+        <div className="mt-4 overflow-x-auto">
+          <table className="min-w-full text-left text-sm text-slate-300/90">
+            <thead className="text-xs uppercase tracking-[0.2em] text-slate-400">
+              <tr>
+                <th className="py-2 pr-4">Period</th>
+                <th className="py-2 pr-4">Total Capital</th>
+                <th className="py-2 pr-4">Δ vs Prior</th>
+                <th className="py-2">Top Backers</th>
+              </tr>
+            </thead>
+            <tbody>
+              {series.map((point) => (
+                <tr key={point.period} className="border-t border-slate-800/60">
+                  <td className="py-3 pr-4 font-medium text-slate-200">{point.period}</td>
+                  <td className="py-3 pr-4">{currencyFormatter.format(point.totalCapitalUsd)}</td>
+                  <td className="py-3 pr-4">{formatChange(point.changePercentage)}</td>
+                  <td className="py-3 text-slate-400/90">{point.topBackers?.join(', ') ?? '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      {notes && notes.length > 0 && (
+        <div className="rounded-2xl border border-slate-700/60 bg-slate-900/30 p-5">
+          <h5 className="text-xs uppercase tracking-[0.3em] text-slate-400">Chart Notes</h5>
+          <ul className="mt-3 space-y-2 text-sm text-slate-300/90">
+            {notes.map((note, index) => (
+              <li key={`${note}-${index}`} className="flex items-start gap-2">
+                <span className="mt-1 h-1.5 w-1.5 rounded-full bg-electric/80" />
+                <span>{note}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/KpiStrip.tsx
+++ b/components/KpiStrip.tsx
@@ -1,0 +1,54 @@
+import type { KpiDatum } from '@/lib/types';
+
+interface KpiStripProps {
+  items: KpiDatum[];
+}
+
+function formatTrend(value?: number, period?: string) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return period ? `vs ${period}` : null;
+  }
+
+  const percentage = (value * 100).toFixed(Math.abs(value * 100) >= 10 ? 0 : 1);
+  const prefix = value > 0 ? '+' : value < 0 ? '−' : '';
+  const body = `${prefix}${Math.abs(Number(percentage)).toString()}%`;
+  return period ? `${body} ${period}` : body;
+}
+
+function trendTone(value?: number) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value === 0) {
+    return 'bg-slate-800/70 border-slate-700/70 text-slate-300';
+  }
+  return value > 0 ? 'bg-emerald-500/15 border-emerald-500/40 text-emerald-300' : 'bg-rose-500/10 border-rose-500/40 text-rose-300';
+}
+
+export function KpiStrip({ items }: KpiStripProps) {
+  if (!items.length) return null;
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      {items.map((item, index) => {
+        const trendLabel = formatTrend(item.trendPercentage, item.trendPeriod);
+        return (
+          <div
+            key={`${item.metric}-${index}`}
+            className="rounded-2xl border border-slate-700/60 bg-slate-900/40 p-5 shadow-inner shadow-black/40 space-y-3"
+          >
+            <div className="text-xs uppercase tracking-[0.3em] text-slate-400/90">{item.metric}</div>
+            <div className="flex items-baseline justify-between gap-3">
+              <span className="text-2xl font-semibold text-white">{item.valueLabel}</span>
+              {trendLabel && (
+                <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-1 text-[0.7rem] font-medium ${trendTone(
+                  item.trendPercentage
+                )}`}>
+                  {trendLabel}
+                </span>
+              )}
+            </div>
+            <p className="text-xs leading-relaxed text-slate-400/90">{item.whyItMatters}</p>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/MilestoneTimeline.tsx
+++ b/components/MilestoneTimeline.tsx
@@ -1,0 +1,67 @@
+import type { TimelineMilestone } from '@/lib/types';
+
+interface MilestoneTimelineProps {
+  items: TimelineMilestone[];
+}
+
+const HORIZON_ORDER: Record<string, number> = {
+  'near-term': 0,
+  'mid-term': 1,
+  'long-term': 2
+};
+
+function formatHorizon(label: string) {
+  const lower = label.toLowerCase();
+  if (lower in HORIZON_ORDER) {
+    return label
+      .split('-')
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join('-');
+  }
+  return label.charAt(0).toUpperCase() + label.slice(1);
+}
+
+function formatConfidence(value: number) {
+  const percent = Math.round(Math.min(Math.max(value, 0), 1) * 100);
+  return `${percent}% confidence`;
+}
+
+export function MilestoneTimeline({ items }: MilestoneTimelineProps) {
+  if (!items.length) return null;
+
+  const enriched = items.map((item, index) => ({ ...item, index }));
+  const sorted = enriched.sort((a, b) => {
+    const horizonDiff = (HORIZON_ORDER[a.horizon.toLowerCase()] ?? 99) - (HORIZON_ORDER[b.horizon.toLowerCase()] ?? 99);
+    if (horizonDiff !== 0) return horizonDiff;
+    return a.index - b.index;
+  });
+
+  return (
+    <ol className="relative space-y-8 border-l border-slate-700/60 pl-6">
+      {sorted.map((item) => (
+        <li key={`${item.window}-${item.milestone}`} className="relative">
+          <span className="absolute -left-3 top-1.5 h-2.5 w-2.5 rounded-full border border-electric/60 bg-slate-900" />
+          <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-electric/70">
+            <span>{formatHorizon(item.horizon)}</span>
+            <span className="text-slate-500">•</span>
+            <span className="text-slate-300/80 normal-case tracking-[0.08em]">{item.window}</span>
+          </div>
+          <p className="mt-2 text-lg font-semibold text-white">{item.milestone}</p>
+          <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-slate-400/90">
+            <span className="rounded-full border border-slate-700/70 bg-slate-900/60 px-3 py-1 font-medium text-slate-200/90">
+              {formatConfidence(item.confidence)}
+            </span>
+            <span className="rounded-full border border-slate-700/70 bg-slate-900/60 px-3 py-1 font-medium text-amber-300/80">
+              Impact: {item.impactLevel}
+            </span>
+            {item.stakeholders.length > 0 && (
+              <span className="truncate text-slate-400/90">
+                Stakeholders: <span className="text-slate-200/90">{item.stakeholders.join(', ')}</span>
+              </span>
+            )}
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/components/TopicViewContent.tsx
+++ b/components/TopicViewContent.tsx
@@ -1,6 +1,9 @@
 import { AdRail } from '@/components/ads/AdRail';
 import { AdInline } from '@/components/ads/AdInline';
 import { HistoryPanel } from '@/components/HistoryPanel';
+import { KpiStrip } from '@/components/KpiStrip';
+import { MilestoneTimeline } from '@/components/MilestoneTimeline';
+import { FundingVisualizer } from '@/components/FundingVisualizer';
 import { getHistory, getTopicById } from '@/lib/data';
 import type { HistoryEntry } from '@/lib/types';
 
@@ -50,16 +53,58 @@ function EmptyState() {
 }
 
 function ArticleBody({ entry }: { entry: HistoryEntry }) {
+  const kpis = entry.data?.kpis ?? [];
+  const timeline = entry.data?.timeline ?? [];
+  const fundingSeries = entry.data?.fundingSeries ?? [];
+  const fundingNotes = entry.data?.fundingChartNotes ?? [];
+  const graphicCue = entry.data?.graphicCue;
+
+  const hasKpis = kpis.length > 0;
+  const hasTimeline = timeline.length > 0;
+  const hasFunding = fundingSeries.length > 1 || (fundingSeries.length === 1 && fundingSeries[0].totalCapitalUsd > 0);
+
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
       <div className="space-y-2">
         <h3 className="text-2xl font-semibold text-electric">{entry.title}</h3>
         <p className="text-slate-300/80 text-sm">{entry.summary}</p>
       </div>
+
+      {hasKpis && (
+        <section aria-label="Key performance indicators" className="space-y-3">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <h4 className="text-xs uppercase tracking-[0.3em] text-slate-400">KPI Strip</h4>
+            {graphicCue && (
+              <span className="rounded-full border border-slate-700/60 bg-slate-900/50 px-3 py-1 text-[0.7rem] uppercase tracking-[0.2em] text-slate-400/90">
+                Graphic Cue: <span className="ml-1 normal-case tracking-normal text-slate-200/90">{graphicCue}</span>
+              </span>
+            )}
+          </div>
+          <KpiStrip items={kpis} />
+        </section>
+      )}
+
+      {hasTimeline && (
+        <section aria-label="Milestone timeline" className="space-y-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <h4 className="text-xs uppercase tracking-[0.3em] text-slate-400">Timeline of Imminent Trials</h4>
+            <span className="text-xs text-slate-400/80">Sequenced by horizon and expected window.</span>
+          </div>
+          <MilestoneTimeline items={timeline} />
+        </section>
+      )}
+
+      {hasFunding && (
+        <section aria-label="Funding flow" className="space-y-4">
+          <h4 className="text-xs uppercase tracking-[0.3em] text-slate-400">Funding Volume Trend</h4>
+          <FundingVisualizer series={fundingSeries} notes={fundingNotes} />
+        </section>
+      )}
+
       <div className="article-body text-slate-200" dangerouslySetInnerHTML={{ __html: entry.content }} />
       {entry.sources.length > 0 && (
         <div className="border-t border-slate-700/60 pt-6">
-          <h4 className="text-sm uppercase tracking-[0.3em] text-slate-400 mb-3">Sources</h4>
+          <h4 className="mb-3 text-sm uppercase tracking-[0.3em] text-slate-400">Sources</h4>
           <ul className="space-y-2 text-sm text-electric/90">
             {entry.sources.map((source) => (
               <li key={source} className="truncate">

--- a/config/ai-config.json
+++ b/config/ai-config.json
@@ -5,7 +5,7 @@
     {
       "id": "longevity",
       "title": "Longevity Research",
-      "prompt": "Provide a deeply sourced, state-of-the-art report on longevity research including rejuvenation biotech, biomarkers, regulatory updates, and funding movements.",
+      "prompt": "Deliver an executive-ready longevity intelligence brief emphasizing current trials, breakthrough timelines, funding flows, and domain-level progress. Populate the structured data contract (kpis, timeline, fundingSeries, chart notes) alongside the narrative so the page can render KPI strips, milestone timelines, and funding graphics. Explicitly cover senolytics, epigenetic reprogramming, stem cell therapies, metabolic interventions, AI-driven discovery, and biomarker platforms with quantified progress notes.",
       "summaryPrompt": "Summarize the most actionable breakthroughs in longevity for executives.",
       "scheduleId": "daily-brief"
     },

--- a/config/instructions.md
+++ b/config/instructions.md
@@ -1,21 +1,67 @@
 # Generation Guardrails for SOTA World Reports
 
-The autonomous researcher must follow these directives when producing content:
+All autonomous research updates must obey these rules before responding:
 
-1. **Evidence First** — Every claim should reference at least one credible source (peer-reviewed paper, reputable news outlet, regulatory filing, earnings call, or company announcement). Provide inline citations in markdown using `[Source Name](URL)`.
-2. **Freshness Guarantee** — Prioritize items published or updated within the last 30 days. If older context is essential, label it as background.
-3. **Signals & Implications** — For each section, explain *why* the development matters for operators, investors, or policymakers.
-4. **Actionable Takeaways** — End each report with 3–5 bullet recommendations keyed to the audience of innovators, executives, and researchers.
-5. **Global Lens** — Include geographic diversity across Americas, EMEA, and APAC when relevant.
-6. **Quantify Impact** — Provide metrics (funding amounts, patient counts, throughput gains, etc.) whenever available.
-7. **Balanced Risk View** — Highlight uncertainties, regulatory risks, or ethical concerns tied to each breakthrough.
-8. **Formatting** — Structure the report with the following sections:
-   - `## Signal Radar` (top 3–5 developments)
-   - `## Investment & Funding Flow`
-   - `## Regulatory & Policy Watch`
-   - `## Frontier Experiments`
-   - `## Action Playbook`
-9. **Tone** — Confident, analytical, and succinct. Avoid hype language; focus on verifiable insight.
-10. **Summaries** — If requested, deliver a 2-paragraph executive summary and 5 bullet key takeaways.
+1. **Evidence First** — Every claim must cite at least one credible source (peer-reviewed paper, reputable news outlet, regulatory filing, earnings call, or company announcement). Use inline markdown citations in the form `[Source Name](URL)`.
+2. **Freshness Guarantee** — Prioritize items published within the last 30 days. Clearly label anything older as background context.
+3. **Signals & Implications** — For each development, explain *why it matters* for operators, investors, or policymakers.
+4. **Actionable Takeaways** — Close with 3–5 bullet recommendations tailored to innovators, executives, and researchers.
+5. **Global Lens** — When relevant, surface activity across the Americas, EMEA, and APAC.
+6. **Quantify Impact** — Provide concrete metrics (funding amounts, trial enrollment, patient outcomes, etc.) whenever available.
+7. **Balanced Risk View** — Flag uncertainties, regulatory risks, or ethical considerations tied to each breakthrough.
+8. **Tone** — Confident, analytical, and succinct. Avoid hype; focus on verifiable intelligence.
+9. **Formatting Discipline** — Use HTML-safe markdown only. Avoid raw HTML elements.
 
-These instructions should be passed verbatim to the model alongside the topic-specific prompt.
+## Layout Requirements by Topic
+
+### Longevity Research (`topicId: longevity`)
+When the topic prompt references longevity research, the response **must** include structured data alongside the narrative so the page can render charts and smart cards. Follow the steps below:
+
+#### Data Output Contract (populate the `data` field of the JSON response)
+
+- `data.kpis`: array of 3–5 objects `{ metric, valueLabel, numericValue (number), unit (string | null), trendPercentage (number, positive = improvement), trendPeriod, whyItMatters }`.
+- `data.graphicCue`: short string describing the TL;DR visual concept.
+- `data.timeline`: array of milestone objects `{ horizon ('near-term' | 'mid-term' | 'long-term'), window, milestone, stakeholders (string[]), confidence (0–1 number), impactLevel ('Low' | 'Medium' | 'High' | custom string) }`.
+- `data.fundingSeries`: chronological array `{ period, totalCapitalUsd (number), changePercentage (number where 0.12 = +12%), topBackers (string[]) }` for at least four recent quarters or years.
+- `data.fundingChartNotes`: 2–4 short strings guiding how to interpret the trend line or stacked area visual.
+
+Ensure numeric fields are actual numbers (not strings) and stakeholders/backers are arrays so the UI can map them directly.
+
+#### Markdown Layout (`markdown` field)
+
+1. `## TL;DR Signal Snapshot`
+   - Start with 3–4 bullet highlights covering the biggest signals of the week.
+   - Reference the KPI strip in prose; **do not** recreate the KPI table manually. The interface renders it from `data.kpis`.
+   - Include the "Graphic Cue" line (plain text) describing the recommended visualization concept.
+
+2. `## Timeline of Imminent Trials`
+   - Open with a short framing paragraph about near-, mid-, and long-term inflection points.
+   - Provide bullet clusters or brief paragraphs keyed to each horizon; the structured milestones will populate the visual timeline automatically.
+
+3. `## Funding Flow Dashboard`
+   - Deliver a 2–3 sentence narrative on capital movement and geographic/sector shifts.
+   - Add a `Chart Notes` bullet list aligning with the entries in `data.fundingChartNotes`. Do not insert a manual funding table.
+
+4. `## Frontier Domains Outlook`
+   - Create subsections (using `###`) for at least four promising longevity domains (e.g., Senolytics, Epigenetic Reprogramming, Stem Cell Therapies, Metabolic Modulators, AI Drug Discovery, Biomarker Platforms).
+   - For each domain provide:
+     - `**Quick Take:**` one-sentence value proposition.
+     - `**Latest Progress:**` 2–3 bullet updates with citations.
+     - `**Next 12–24 Month Outlook:**` 1–2 sentences on upcoming catalysts or risks.
+
+5. `## Public Readiness Brief`
+   - Deliver a 2–3 paragraph explainer in approachable language for non-experts covering: what the field aims to achieve, how today’s milestones affect everyday life, and safety/ethical considerations.
+   - Close with a short `Key Questions from the Public` bullet list addressing common concerns.
+
+6. `## Action Playbook`
+   - 3–5 bullets outlining recommended moves for executives, researchers, and policymakers.
+
+### Other Topics
+For topics other than longevity, preserve the previous structure:
+- `## Signal Radar`
+- `## Investment & Funding Flow`
+- `## Regulatory & Policy Watch`
+- `## Frontier Experiments`
+- `## Action Playbook`
+
+Ensure every section label appears exactly as specified for the respective topic so downstream rendering remains consistent.

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -15,6 +15,40 @@ export interface ScheduleConfig {
   timezone?: string;
 }
 
+export interface KpiDatum {
+  metric: string;
+  valueLabel: string;
+  numericValue?: number;
+  unit?: string | null;
+  trendPercentage?: number;
+  trendPeriod?: string;
+  whyItMatters: string;
+}
+
+export interface TimelineMilestone {
+  horizon: 'near-term' | 'mid-term' | 'long-term' | string;
+  window: string;
+  milestone: string;
+  stakeholders: string[];
+  confidence: number;
+  impactLevel: string;
+}
+
+export interface FundingPoint {
+  period: string;
+  totalCapitalUsd: number;
+  changePercentage?: number;
+  topBackers?: string[];
+}
+
+export interface TopicVisualData {
+  kpis?: KpiDatum[];
+  graphicCue?: string;
+  timeline?: TimelineMilestone[];
+  fundingSeries?: FundingPoint[];
+  fundingChartNotes?: string[];
+}
+
 export interface HistoryEntry {
   id: string;
   topicId: string;
@@ -23,6 +57,7 @@ export interface HistoryEntry {
   summary: string;
   content: string;
   sources: string[];
+  data?: TopicVisualData;
 }
 
 export interface GenerationPayload {

--- a/scripts/updateContent.ts
+++ b/scripts/updateContent.ts
@@ -14,7 +14,14 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { marked } from 'marked';
 import { randomUUID } from 'crypto';
-import type { HistoryEntry, TopicConfig } from '@/lib/types';
+import type {
+  FundingPoint,
+  HistoryEntry,
+  KpiDatum,
+  TimelineMilestone,
+  TopicConfig,
+  TopicVisualData
+} from '@/lib/types';
 import { getInstructions, saveHistory } from '@/lib/data';
 
 interface AIConfig {
@@ -168,13 +175,46 @@ function mockContent(topic: TopicConfig): string {
   return JSON.stringify({
     title: `${topic.title} — Mock Insight`,
     summary: 'Development mode summary. Connect the Vercel AI Gateway to receive live intelligence.',
-    markdown: `## Signal Radar\n- Placeholder update for ${topic.title}.\n\n## Investment & Funding Flow\n- Sample funding note.\n\n## Regulatory & Policy Watch\n- Sample regulation note.\n\n## Frontier Experiments\n- Sample experiment.\n\n## Action Playbook\n- Align data infrastructure for upcoming updates.`,
-    sources: ['https://example.com/mock-source']
+    markdown: `## TL;DR Signal Snapshot\n- Placeholder highlight for ${topic.title}.\n- Add real data by configuring the AI gateway.\n- Funding insights and domain outlooks will appear here.\n\nGraphic Cue: radial dial showing mock readiness level.\n\n## Timeline of Imminent Trials\nA real report will describe upcoming trials across horizons.\n\n## Funding Flow Dashboard\nFunding commentary will render once live data is available.\n\nChart Notes\n- Connect the gateway to populate funding trends.\n\n## Frontier Domains Outlook\n### Mock Domain\n**Quick Take:** Placeholder.\n\n**Latest Progress:**\n- Update pending.\n\n**Next 12–24 Month Outlook:** Real milestones appear once the gateway is configured.\n\n## Public Readiness Brief\nThis section will translate longevity breakthroughs for broader audiences.\n\nKey Questions from the Public\n- When will real data arrive?\n\n## Action Playbook\n- Configure the AI gateway to replace this mock content.`,
+    sources: ['https://example.com/mock-source'],
+    data: {
+      kpis: [
+        {
+          metric: 'Active Longevity Trials',
+          valueLabel: '—',
+          numericValue: 0,
+          unit: 'trials',
+          trendPercentage: 0,
+          trendPeriod: 'QoQ',
+          whyItMatters: 'Connect the data pipeline to display live trial counts.'
+        }
+      ],
+      graphicCue: 'Radial gauge showing share of phase III assets on track.',
+      timeline: [
+        {
+          horizon: 'near-term',
+          window: 'Next 12 months',
+          milestone: 'Real milestones will appear after data generation is enabled.',
+          stakeholders: ['SOTA World'],
+          confidence: 0.5,
+          impactLevel: 'Medium'
+        }
+      ],
+      fundingSeries: [
+        {
+          period: '2024 Q1',
+          totalCapitalUsd: 0,
+          changePercentage: 0,
+          topBackers: ['Enable gateway for investors']
+        }
+      ],
+      fundingChartNotes: ['Chart will render once fundingSeries contains real datapoints.']
+    } satisfies TopicVisualData
   });
 }
 
 async function transformToHistoryEntry(topicId: string, output: string): Promise<HistoryEntry> {
-  let parsed: { title: string; summary: string; markdown: string; sources: string[] };
+  let parsed: { title: string; summary: string; markdown: string; sources?: unknown; data?: unknown };
   try {
     parsed = JSON.parse(output);
   } catch (error) {
@@ -188,6 +228,8 @@ async function transformToHistoryEntry(topicId: string, output: string): Promise
   }
 
   const html = await marked.parse(parsed.markdown);
+  const sources = normalizeSources(parsed.sources);
+  const visualData = normalizeVisualData(parsed.data);
 
   return {
     id: randomUUID(),
@@ -196,8 +238,178 @@ async function transformToHistoryEntry(topicId: string, output: string): Promise
     title: parsed.title,
     summary: parsed.summary,
     content: html,
-    sources: parsed.sources ?? []
+    sources,
+    ...(visualData ? { data: visualData } : {})
   };
+}
+
+function normalizeSources(input: unknown): string[] {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+
+  return input
+    .map((item) => (typeof item === 'string' ? item.trim() : ''))
+    .filter((item): item is string => item.length > 0);
+}
+
+function normalizeVisualData(input: unknown): TopicVisualData | undefined {
+  if (!input || typeof input !== 'object') {
+    return undefined;
+  }
+
+  const raw = input as Record<string, unknown>;
+
+  const kpis = Array.isArray(raw.kpis)
+    ? raw.kpis
+        .map((item) => {
+          if (!item || typeof item !== 'object') return null;
+          const metric = typeof (item as { metric?: unknown }).metric === 'string' ? (item as { metric?: string }).metric!.trim() : '';
+          const valueLabel =
+            typeof (item as { valueLabel?: unknown }).valueLabel === 'string'
+              ? (item as { valueLabel?: string }).valueLabel!.trim()
+              : '';
+          const whyItMatters =
+            typeof (item as { whyItMatters?: unknown }).whyItMatters === 'string'
+              ? (item as { whyItMatters?: string }).whyItMatters!.trim()
+              : '';
+
+          if (!metric || !valueLabel || !whyItMatters) {
+            return null;
+          }
+
+          const numericValueRaw = (item as { numericValue?: unknown }).numericValue;
+          const numericValue = typeof numericValueRaw === 'number' && Number.isFinite(numericValueRaw) ? numericValueRaw : undefined;
+
+          const unitRaw = (item as { unit?: unknown }).unit;
+          const unit = typeof unitRaw === 'string' ? unitRaw : unitRaw === null ? null : undefined;
+
+          const trendPercentageRaw = (item as { trendPercentage?: unknown }).trendPercentage;
+          const trendPercentage = typeof trendPercentageRaw === 'number' && Number.isFinite(trendPercentageRaw) ? trendPercentageRaw : undefined;
+
+          const trendPeriodRaw = (item as { trendPeriod?: unknown }).trendPeriod;
+          const trendPeriod = typeof trendPeriodRaw === 'string' && trendPeriodRaw.trim() ? trendPeriodRaw.trim() : undefined;
+
+          return {
+            metric,
+            valueLabel,
+            whyItMatters,
+            ...(numericValue !== undefined ? { numericValue } : {}),
+            ...(unit !== undefined ? { unit } : {}),
+            ...(trendPercentage !== undefined ? { trendPercentage } : {}),
+            ...(trendPeriod ? { trendPeriod } : {})
+          } as KpiDatum;
+        })
+        .filter((item): item is KpiDatum => item !== null && item.metric.length > 0)
+    : undefined;
+
+  const timeline = Array.isArray(raw.timeline)
+    ? raw.timeline
+        .map((item, index) => {
+          if (!item || typeof item !== 'object') return null;
+          const horizonRaw = (item as { horizon?: unknown }).horizon;
+          const window = typeof (item as { window?: unknown }).window === 'string' ? (item as { window?: string }).window!.trim() : '';
+          const milestone =
+            typeof (item as { milestone?: unknown }).milestone === 'string'
+              ? (item as { milestone?: string }).milestone!.trim()
+              : '';
+
+          if (!window || !milestone) {
+            return null;
+          }
+
+          const stakeholdersRaw = (item as { stakeholders?: unknown }).stakeholders;
+          const stakeholders = Array.isArray(stakeholdersRaw)
+            ? stakeholdersRaw
+                .map((value) => (typeof value === 'string' ? value.trim() : ''))
+                .filter((value): value is string => value.length > 0)
+            : [];
+
+          const confidenceRaw = (item as { confidence?: unknown }).confidence;
+          const confidence =
+            typeof confidenceRaw === 'number' && Number.isFinite(confidenceRaw)
+              ? Math.min(Math.max(confidenceRaw, 0), 1)
+              : 0.5;
+
+          const impactLevelRaw = (item as { impactLevel?: unknown }).impactLevel;
+          const impactLevel = typeof impactLevelRaw === 'string' && impactLevelRaw.trim() ? impactLevelRaw.trim() : '—';
+
+          const normalizedHorizon =
+            typeof horizonRaw === 'string' && horizonRaw.trim().length > 0 ? horizonRaw.trim() : (['near-term', 'mid-term', 'long-term'][Math.min(index, 2)] ?? 'near-term');
+
+          return {
+            horizon: normalizedHorizon,
+            window,
+            milestone,
+            stakeholders,
+            confidence,
+            impactLevel
+          } as TimelineMilestone;
+        })
+        .filter((item): item is TimelineMilestone => item !== null)
+    : undefined;
+
+  const fundingSeries = Array.isArray(raw.fundingSeries)
+    ? raw.fundingSeries
+        .map((item) => {
+          if (!item || typeof item !== 'object') return null;
+          const period = typeof (item as { period?: unknown }).period === 'string' ? (item as { period?: string }).period!.trim() : '';
+          const totalCapitalRaw = (item as { totalCapitalUsd?: unknown }).totalCapitalUsd;
+          const totalCapitalUsd = typeof totalCapitalRaw === 'number' && Number.isFinite(totalCapitalRaw) ? totalCapitalRaw : undefined;
+
+          if (!period || totalCapitalUsd === undefined) {
+            return null;
+          }
+
+          const changeRaw = (item as { changePercentage?: unknown }).changePercentage;
+          const changePercentage = typeof changeRaw === 'number' && Number.isFinite(changeRaw) ? changeRaw : undefined;
+
+          const topBackersRaw = (item as { topBackers?: unknown }).topBackers;
+          const topBackers = Array.isArray(topBackersRaw)
+            ? topBackersRaw
+                .map((value) => (typeof value === 'string' ? value.trim() : ''))
+                .filter((value): value is string => value.length > 0)
+            : undefined;
+
+          return {
+            period,
+            totalCapitalUsd,
+            ...(changePercentage !== undefined ? { changePercentage } : {}),
+            ...(topBackers && topBackers.length > 0 ? { topBackers } : {})
+          } as FundingPoint;
+        })
+        .filter((item): item is FundingPoint => item !== null)
+    : undefined;
+
+  const fundingChartNotes = Array.isArray(raw.fundingChartNotes)
+    ? raw.fundingChartNotes
+        .map((item) => (typeof item === 'string' ? item.trim() : ''))
+        .filter((item): item is string => item.length > 0)
+    : undefined;
+
+  const graphicCueRaw = raw.graphicCue;
+  const graphicCue = typeof graphicCueRaw === 'string' && graphicCueRaw.trim() ? graphicCueRaw.trim() : undefined;
+
+  const hasContent = Boolean(
+    (kpis && kpis.length > 0) ||
+      (timeline && timeline.length > 0) ||
+      (fundingSeries && fundingSeries.length > 0) ||
+      (fundingChartNotes && fundingChartNotes.length > 0) ||
+      graphicCue
+  );
+
+  if (!hasContent) {
+    return undefined;
+  }
+
+  const normalized: TopicVisualData = {};
+  if (kpis && kpis.length > 0) normalized.kpis = kpis;
+  if (timeline && timeline.length > 0) normalized.timeline = timeline;
+  if (fundingSeries && fundingSeries.length > 0) normalized.fundingSeries = fundingSeries;
+  if (fundingChartNotes && fundingChartNotes.length > 0) normalized.fundingChartNotes = fundingChartNotes;
+  if (graphicCue) normalized.graphicCue = graphicCue;
+
+  return normalized;
 }
 
 function extractContent(result: unknown): string {


### PR DESCRIPTION
## Summary
- require longevity reports to populate a structured data contract powering KPI, timeline, and funding visuals
- update the longevity topic prompt and ingestion script to persist the new chart data fields
- add KPI, milestone timeline, and funding visualization components and surface them in the topic view

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2c62d5f7883259992e4f8c5d8a726